### PR TITLE
Restyle queue screen with glassy quick menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,71 @@
 # Poptask
 
-A lightweight queue-style task web app designed for quick captures and satisfying completions. Built with vanilla HTML, CSS, and JavaScript so it can be served statically and opened on mobile browsers (including iPhone Safari).
+Poptask is a queue-inspired task manager that runs entirely in the browser. It focuses on fast capture, deadline awareness, and a playful "pop" moment when you finish a task. The app is built with vanilla HTML, CSS, and JavaScript so it can be hosted anywhere that serves static files and works great on phones.
 
 ## Features
 
-- 📋 **Queue-first layout** – tasks are displayed as cards sorted by deadline or by the time you added them.
-- ⏰ **Flexible deadlines** – choose an exact date/time or set relative reminders like “in 5 minutes” or “in 1 hour”.
-- 🎉 **Pleasant pop interaction** – finishing a task triggers a pop animation and moves the task into an archive list.
-- 🗃️ **Archive view** – revisit completed tasks and clear them when you’re done celebrating.
-- 💾 **Offline-friendly** – all data is stored in your browser’s `localStorage`, so nothing leaves your device.
-- 📱 **Mobile-ready** – responsive layout and large tap targets make the app comfortable on phones.
-
-## Getting started
-
-1. Serve the folder with any static web server. A simple option is Python’s built-in server:
-
-   ```bash
-   python -m http.server 4173
-   ```
-
-2. Open your browser and navigate to `http://localhost:4173` (or the URL your server prints). On mobile, host the site and share the network URL, or deploy the folder to any static hosting provider.
-
-3. Add tasks from the floating action button, then pop them once completed!
+- 📋 **Queue-first home screen** – tasks appear as cards ordered by the soonest deadline or by when they were created.
+- ⏱️ **Flexible deadlines** – choose an exact date & time or pick relative timers such as "in 5 minutes" or "in 2 hours".
+- 🎉 **Satisfying completion** – tapping *Pop* fires a celebratory animation and moves the task into the archive view.
+- 🗃️ **Archive log** – review completed tasks, restore them if needed, or clear the history in one tap.
+- 💾 **Offline-friendly** – everything is persisted in `localStorage`; no account or backend required.
+- 📱 **Mobile tuned** – responsive layout, large touch targets, and glassmorphism styling feel at home on iPhone Safari.
+- ♿ **Reduced motion aware** – respects the `prefers-reduced-motion` setting and softens effects automatically.
 
 ## Project structure
 
 ```
 Poptask/
-├── index.html        # Main queue view
-├── add.html          # Task creation form
-├── archive.html      # Completed task archive
+├── index.html        # Queue view
+├── add.html          # Task creation flow
+├── archive.html      # Archive view
 ├── scripts/
-│   ├── add.js        # Form logic
-│   ├── archive.js    # Archive rendering
-│   ├── index.js      # Queue interactions
-│   └── storage.js    # LocalStorage helpers
+│   ├── add.js        # Add-task form logic
+│   ├── archive.js    # Archive rendering & controls
+│   ├── index.js      # Queue interactions & animations
+│   └── storage.js    # Shared storage helpers
 └── styles/
-    └── main.css      # Global styling
+    └── main.css      # Shared styling and component rules
 ```
 
-## Notes
+## Local usage
 
-- Tasks and archive entries live entirely in `localStorage`; clearing browser data will reset the app.
-- Animations are minimized automatically for users who prefer reduced motion.
-- The design uses system fonts for fast rendering and a clean appearance.
+1. **Install a static server.** Any static host works. A quick option already bundled with Python is:
+
+   ```bash
+   python -m http.server 4173
+   ```
+
+2. **Serve the project root.** Run the command above while inside the `Poptask/` directory.
+
+3. **Open the app.** Visit the printed URL (for example `http://localhost:4173`) in your browser. On an iPhone, make sure your computer and phone are on the same network and open the LAN URL that Python displays.
+
+4. **Add tasks.** Tap the floating **Add** button, fill in the name, description, and deadline (absolute or relative), then press **Save**.
+
+5. **Work the queue.** Tasks rise to the top as deadlines approach. Pop finished tasks to archive them and keep the queue clean.
+
+6. **Review history.** Access the archive from the quick menu to revisit popped tasks or clear the log.
+
+All task data is stored locally in the browser. Clearing site data or switching devices resets the queue.
+
+## Deployment
+
+Because the app is static, you can deploy it with any file host:
+
+- **GitHub Pages** – push this repository to GitHub and enable Pages for the main branch or `docs/` folder.
+- **Netlify / Vercel / Render** – create a new site from this repository; no build step is required.
+- **S3 / Cloudflare R2 / Azure Storage** – upload the files and expose them via static website hosting.
+- **Self-hosted** – drop the folder onto any web server (Nginx, Apache, etc.) and point a domain at it.
+
+The entry point is `index.html`. Ensure your host serves the files with standard text content types (e.g., `text/html`, `text/css`, `application/javascript`).
+
+## Development notes
+
+- The codebase intentionally avoids frameworks to stay lightweight and portable. If you want to expand functionality, the vanilla structure makes it easy to integrate your preferred build tooling.
+- CSS variables in `styles/main.css` centralize colors, shadows, and glass effects. Tweak them to adjust the visual design.
+- `scripts/storage.js` wraps `localStorage` access and handles serialization, making it the best place to add future persistence features.
+- Animations are powered by the Web Animations API to achieve smooth transitions without external libraries.
+
+## License
+
+This project is provided as-is for personal and educational use. Feel free to adapt it for your own deployments.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,46 @@
 # Poptask
+
+A lightweight queue-style task web app designed for quick captures and satisfying completions. Built with vanilla HTML, CSS, and JavaScript so it can be served statically and opened on mobile browsers (including iPhone Safari).
+
+## Features
+
+- 📋 **Queue-first layout** – tasks are displayed as cards sorted by deadline or by the time you added them.
+- ⏰ **Flexible deadlines** – choose an exact date/time or set relative reminders like “in 5 minutes” or “in 1 hour”.
+- 🎉 **Pleasant pop interaction** – finishing a task triggers a pop animation and moves the task into an archive list.
+- 🗃️ **Archive view** – revisit completed tasks and clear them when you’re done celebrating.
+- 💾 **Offline-friendly** – all data is stored in your browser’s `localStorage`, so nothing leaves your device.
+- 📱 **Mobile-ready** – responsive layout and large tap targets make the app comfortable on phones.
+
+## Getting started
+
+1. Serve the folder with any static web server. A simple option is Python’s built-in server:
+
+   ```bash
+   python -m http.server 4173
+   ```
+
+2. Open your browser and navigate to `http://localhost:4173` (or the URL your server prints). On mobile, host the site and share the network URL, or deploy the folder to any static hosting provider.
+
+3. Add tasks from the floating action button, then pop them once completed!
+
+## Project structure
+
+```
+Poptask/
+├── index.html        # Main queue view
+├── add.html          # Task creation form
+├── archive.html      # Completed task archive
+├── scripts/
+│   ├── add.js        # Form logic
+│   ├── archive.js    # Archive rendering
+│   ├── index.js      # Queue interactions
+│   └── storage.js    # LocalStorage helpers
+└── styles/
+    └── main.css      # Global styling
+```
+
+## Notes
+
+- Tasks and archive entries live entirely in `localStorage`; clearing browser data will reset the app.
+- Animations are minimized automatically for users who prefer reduced motion.
+- The design uses system fonts for fast rendering and a clean appearance.

--- a/add.html
+++ b/add.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Add a task • Poptask</title>
+    <link rel="stylesheet" href="styles/main.css" />
+  </head>
+  <body class="form-page">
+    <header class="form-header">
+      <a class="back-link" href="index.html" aria-label="Back to task list">←</a>
+      <h1>Add a task</h1>
+      <span class="back-link placeholder" aria-hidden="true">←</span>
+    </header>
+
+    <main class="form-main">
+      <form id="taskForm" class="task-form" novalidate>
+        <div class="field-group">
+          <label for="taskTitle">Task name<span aria-hidden="true">*</span></label>
+          <input id="taskTitle" name="title" type="text" required maxlength="100" placeholder="What needs to be done?" autocomplete="off" />
+          <p class="field-hint" id="titleHint">Make it short and clear.</p>
+        </div>
+
+        <div class="field-group">
+          <label for="taskDescription">Description</label>
+          <textarea id="taskDescription" name="description" rows="4" placeholder="Add context or steps (optional)"></textarea>
+        </div>
+
+        <fieldset class="field-group" id="deadlineOptions">
+          <legend>Deadline</legend>
+          <div class="radio-grid">
+            <label class="radio-chip">
+              <input type="radio" name="deadlineType" value="none" checked />
+              <span>No deadline</span>
+            </label>
+            <label class="radio-chip">
+              <input type="radio" name="deadlineType" value="absolute" />
+              <span>Exact date &amp; time</span>
+            </label>
+            <label class="radio-chip">
+              <input type="radio" name="deadlineType" value="relative" />
+              <span>After a period</span>
+            </label>
+          </div>
+
+          <div class="deadline-field deadline-field--absolute" hidden>
+            <label for="deadlineDate">Select date</label>
+            <input id="deadlineDate" name="deadlineDate" type="date" />
+            <label for="deadlineTime">Select time</label>
+            <input id="deadlineTime" name="deadlineTime" type="time" />
+          </div>
+
+          <div class="deadline-field deadline-field--relative" hidden>
+            <label for="deadlineRelative">Remind me after</label>
+            <select id="deadlineRelative" name="deadlineRelative">
+              <option value="300000">5 minutes</option>
+              <option value="900000">15 minutes</option>
+              <option value="1800000">30 minutes</option>
+              <option value="3600000">1 hour</option>
+              <option value="7200000">2 hours</option>
+              <option value="86400000">1 day</option>
+              <option value="172800000">2 days</option>
+              <option value="604800000">1 week</option>
+            </select>
+          </div>
+        </fieldset>
+
+        <div class="form-actions">
+          <button type="submit" class="primary-button">Add to queue</button>
+          <a class="secondary-button" href="index.html">Cancel</a>
+        </div>
+      </form>
+    </main>
+
+    <script type="module" src="scripts/add.js"></script>
+  </body>
+</html>

--- a/archive.html
+++ b/archive.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Archive • Poptask</title>
+    <link rel="stylesheet" href="styles/main.css" />
+  </head>
+  <body class="archive-page">
+    <header class="archive-header">
+      <a class="back-link" href="index.html" aria-label="Back to task list">←</a>
+      <h1>Archive</h1>
+      <button class="clear-archive" id="clearArchive" type="button">Clear</button>
+    </header>
+
+    <main class="archive-main">
+      <section class="archive-list" id="archiveList" aria-live="polite">
+        <div class="empty-state" id="archiveEmpty">
+          <h3>No popped tasks yet.</h3>
+          <p>Pop a task to celebrate the progress!</p>
+        </div>
+      </section>
+    </main>
+
+    <script type="module" src="scripts/archive.js"></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Poptask</title>
+    <link rel="stylesheet" href="styles/main.css" />
+  </head>
+  <body>
+    <div class="app-shell">
+      <header class="app-header">
+        <button class="icon-button" id="menuToggle" type="button" aria-expanded="false" aria-controls="actionPanel" aria-label="Open quick menu">
+          <span aria-hidden="true">☰</span>
+        </button>
+        <div class="app-heading">
+          <h1>Poptask</h1>
+        </div>
+        <div class="queue-count" aria-live="polite">
+          <span id="activeCount" class="queue-count__value">0</span>
+          <span class="queue-count__label">active</span>
+        </div>
+      </header>
+
+      <main class="app-main" id="mainContent">
+        <section class="task-list" id="taskList" aria-live="polite">
+          <div class="empty-state" id="emptyState">
+            <h2>You're all clear.</h2>
+            <p>Tap the plus to capture the next thing on your mind.</p>
+          </div>
+        </section>
+      </main>
+    </div>
+
+    <a class="fab" href="add.html" aria-label="Add a task">
+      <span aria-hidden="true">+</span>
+    </a>
+
+    <div class="panel-overlay" id="panelOverlay" hidden></div>
+    <aside class="action-panel" id="actionPanel" role="dialog" aria-modal="true" aria-labelledby="actionPanelTitle" aria-hidden="true">
+      <div class="action-panel__header">
+        <h2 id="actionPanelTitle">Quick menu</h2>
+        <button class="icon-button" id="closePanel" type="button" aria-label="Close quick menu">
+          <span aria-hidden="true">×</span>
+        </button>
+      </div>
+      <div class="action-panel__section">
+        <h3>Sort tasks</h3>
+        <div class="panel-toggle" role="radiogroup" aria-label="Sorting preference">
+          <button class="panel-toggle__chip" data-sort="deadline" role="radio" aria-checked="true">
+            Deadline
+          </button>
+          <button class="panel-toggle__chip" data-sort="created" role="radio" aria-checked="false">
+            Added time
+          </button>
+        </div>
+      </div>
+      <div class="action-panel__section">
+        <h3>Archive</h3>
+        <p>Celebrate your progress whenever you need a boost.</p>
+        <a class="panel-link" href="archive.html">Open archive</a>
+      </div>
+    </aside>
+
+    <template id="taskTemplate">
+      <article class="task-card">
+        <div class="task-card__content">
+          <div class="task-card__header">
+            <h3 class="task-card__title"></h3>
+            <p class="task-card__deadline" aria-live="polite"></p>
+          </div>
+          <p class="task-card__description"></p>
+        </div>
+        <div class="task-card__actions">
+          <button class="pop-button" type="button">
+            <span>Pop</span>
+          </button>
+        </div>
+      </article>
+    </template>
+
+    <script type="module" src="scripts/index.js"></script>
+  </body>
+</html>

--- a/scripts/add.js
+++ b/scripts/add.js
@@ -1,0 +1,107 @@
+import { addTask, generateId } from './storage.js';
+
+const form = document.getElementById('taskForm');
+const deadlineOptions = Array.from(
+  document.querySelectorAll('input[name="deadlineType"]')
+);
+const absoluteField = document.querySelector('.deadline-field--absolute');
+const relativeField = document.querySelector('.deadline-field--relative');
+const titleInput = document.getElementById('taskTitle');
+const descriptionInput = document.getElementById('taskDescription');
+const dateInput = document.getElementById('deadlineDate');
+const timeInput = document.getElementById('deadlineTime');
+const relativeSelect = document.getElementById('deadlineRelative');
+
+if (dateInput) {
+  const today = new Date();
+  const offset = today.getTimezoneOffset();
+  today.setMinutes(today.getMinutes() - offset);
+  dateInput.min = today.toISOString().split('T')[0];
+}
+
+function toggleDeadlineFields() {
+  const selected = deadlineOptions.find((option) => option.checked)?.value;
+  absoluteField.hidden = selected !== 'absolute';
+  relativeField.hidden = selected !== 'relative';
+}
+
+deadlineOptions.forEach((option) => {
+  option.addEventListener('change', toggleDeadlineFields);
+});
+
+toggleDeadlineFields();
+
+titleInput.addEventListener('input', () => clearValidation(titleInput));
+
+function buildDeadline() {
+  const selected = deadlineOptions.find((option) => option.checked)?.value;
+  const now = new Date();
+
+  if (selected === 'absolute') {
+    if (!dateInput.value) {
+      return null;
+    }
+    const timeValue = timeInput.value || '00:00';
+    const [hours, minutes] = timeValue.split(':').map(Number);
+    const due = new Date(dateInput.value);
+    if (!Number.isNaN(hours) && !Number.isNaN(minutes)) {
+      due.setHours(hours, minutes, 0, 0);
+    }
+    if (due.getTime() < now.getTime()) {
+      return due.toISOString();
+    }
+    return due.toISOString();
+  }
+
+  if (selected === 'relative') {
+    const offset = Number(relativeSelect.value);
+    if (!Number.isNaN(offset)) {
+      return new Date(now.getTime() + offset).toISOString();
+    }
+  }
+
+  return null;
+}
+
+function showValidationError(field, message) {
+  field.classList.add('is-invalid');
+  field.setAttribute('aria-invalid', 'true');
+  if (message) {
+    field.setCustomValidity(message);
+  }
+}
+
+function clearValidation(field) {
+  field.classList.remove('is-invalid');
+  field.removeAttribute('aria-invalid');
+  field.setCustomValidity('');
+}
+
+form.addEventListener('submit', (event) => {
+  event.preventDefault();
+  clearValidation(titleInput);
+
+  const title = titleInput.value.trim();
+  if (!title) {
+    showValidationError(titleInput, 'Please give the task a name.');
+    titleInput.reportValidity();
+    return;
+  }
+
+  const description = descriptionInput.value.trim();
+  const deadline = buildDeadline();
+
+  const task = {
+    id: generateId(),
+    title,
+    description,
+    deadline,
+    createdAt: new Date().toISOString(),
+  };
+
+  addTask(task);
+
+  form.reset();
+  toggleDeadlineFields();
+  window.location.href = 'index.html';
+});

--- a/scripts/archive.js
+++ b/scripts/archive.js
@@ -1,0 +1,76 @@
+import { getArchive, clearArchive } from './storage.js';
+
+const list = document.getElementById('archiveList');
+const empty = document.getElementById('archiveEmpty');
+const clearButton = document.getElementById('clearArchive');
+
+function formatTimestamp(value) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+  }).format(date);
+}
+
+function renderArchive() {
+  const archive = getArchive();
+  list.innerHTML = '';
+
+  if (!archive.length) {
+    empty.style.display = 'grid';
+    return;
+  }
+
+  empty.style.display = 'none';
+
+  archive.forEach((task) => {
+    const card = document.createElement('article');
+    card.className = 'archive-card';
+
+    const title = document.createElement('h3');
+    title.textContent = task.title;
+
+    const description = document.createElement('p');
+    description.textContent = task.description || 'No additional details';
+
+    const meta = document.createElement('p');
+    meta.className = 'archive-card__meta';
+    const completed = formatTimestamp(task.completedAt);
+    const created = formatTimestamp(task.createdAt);
+    const deadline = task.deadline ? formatTimestamp(task.deadline) : null;
+
+    meta.textContent = [
+      completed ? `Popped ${completed}` : null,
+      deadline ? `Due ${deadline}` : null,
+      created ? `Added ${created}` : null,
+    ]
+      .filter(Boolean)
+      .join(' • ');
+
+    card.appendChild(title);
+    card.appendChild(description);
+    if (meta.textContent) {
+      card.appendChild(meta);
+    }
+
+    list.appendChild(card);
+  });
+}
+
+clearButton.addEventListener('click', () => {
+  if (!getArchive().length) {
+    return;
+  }
+  const confirmed = window.confirm('Clear all popped tasks?');
+  if (confirmed) {
+    clearArchive();
+    renderArchive();
+  }
+});
+
+renderArchive();

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -1,0 +1,248 @@
+import { getTasks, saveTasks, addToArchive } from './storage.js';
+
+const taskList = document.getElementById('taskList');
+const taskTemplate = document.getElementById('taskTemplate');
+const emptyState = document.getElementById('emptyState');
+const activeCount = document.getElementById('activeCount');
+const sortButtons = document.querySelectorAll('.panel-toggle__chip');
+const menuToggle = document.getElementById('menuToggle');
+const panelOverlay = document.getElementById('panelOverlay');
+const actionPanel = document.getElementById('actionPanel');
+const closePanelButton = document.getElementById('closePanel');
+
+let sortPreference = localStorage.getItem('poptask_sort') || 'deadline';
+let isPanelOpen = false;
+let panelFocusTimeout;
+
+function syncPanelState(isOpen) {
+  if (isOpen) {
+    panelOverlay.hidden = false;
+    requestAnimationFrame(() => {
+      panelOverlay.classList.add('is-visible');
+      actionPanel.classList.add('is-visible');
+    });
+    actionPanel.setAttribute('aria-hidden', 'false');
+    menuToggle.setAttribute('aria-expanded', 'true');
+    panelFocusTimeout = window.setTimeout(() => {
+      closePanelButton.focus({ preventScroll: true });
+    }, 180);
+    document.addEventListener('keydown', handlePanelKeyDown);
+  } else {
+    if (panelFocusTimeout) {
+      window.clearTimeout(panelFocusTimeout);
+      panelFocusTimeout = undefined;
+    }
+    panelOverlay.classList.remove('is-visible');
+    actionPanel.classList.remove('is-visible');
+    actionPanel.setAttribute('aria-hidden', 'true');
+    menuToggle.setAttribute('aria-expanded', 'false');
+    document.removeEventListener('keydown', handlePanelKeyDown);
+    const handleTransitionEnd = (event) => {
+      if (event.target === panelOverlay && !isPanelOpen) {
+        panelOverlay.hidden = true;
+        panelOverlay.removeEventListener('transitionend', handleTransitionEnd);
+      }
+    };
+    panelOverlay.addEventListener('transitionend', handleTransitionEnd);
+    menuToggle.focus({ preventScroll: true });
+  }
+}
+
+function openPanel() {
+  if (isPanelOpen) return;
+  isPanelOpen = true;
+  syncPanelState(true);
+}
+
+function closePanel() {
+  if (!isPanelOpen) return;
+  isPanelOpen = false;
+  syncPanelState(false);
+}
+
+function handlePanelKeyDown(event) {
+  if (event.key === 'Escape') {
+    closePanel();
+  }
+}
+
+function setSortPreference(newValue) {
+  sortPreference = newValue;
+  localStorage.setItem('poptask_sort', newValue);
+  sortButtons.forEach((button) => {
+    const isActive = button.dataset.sort === newValue;
+    button.setAttribute('aria-checked', String(isActive));
+  });
+}
+
+function formatDuration(ms) {
+  const abs = Math.abs(ms);
+  const minute = 60 * 1000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  const week = 7 * day;
+
+  if (abs < minute) {
+    return 'a moment';
+  }
+  if (abs < hour) {
+    const value = Math.round(abs / minute);
+    return `${value} minute${value === 1 ? '' : 's'}`;
+  }
+  if (abs < day) {
+    const value = Math.round(abs / hour * 10) / 10;
+    return `${value % 1 === 0 ? value.toFixed(0) : value.toFixed(1)} hour${value === 1 ? '' : 's'}`;
+  }
+  if (abs < week) {
+    const value = Math.round(abs / day * 10) / 10;
+    return `${value % 1 === 0 ? value.toFixed(0) : value.toFixed(1)} day${value === 1 ? '' : 's'}`;
+  }
+  const value = Math.round(abs / week * 10) / 10;
+  return `${value % 1 === 0 ? value.toFixed(0) : value.toFixed(1)} week${value === 1 ? '' : 's'}`;
+}
+
+function formatDeadline(task) {
+  if (!task.deadline) {
+    return 'No deadline';
+  }
+  const due = new Date(task.deadline);
+  if (Number.isNaN(due.getTime())) {
+    return 'No deadline';
+  }
+
+  const now = Date.now();
+  const diff = due.getTime() - now;
+  const dateFormatter = new Intl.DateTimeFormat(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+  });
+
+  if (Math.abs(diff) < 60 * 1000) {
+    return 'Due now';
+  }
+
+  if (diff > 0) {
+    return `Due in ${formatDuration(diff)} • ${dateFormatter.format(due)}`;
+  }
+  return `Overdue by ${formatDuration(diff)} • ${dateFormatter.format(due)}`;
+}
+
+function sortTasks(tasks) {
+  const sorted = [...tasks];
+  if (sortPreference === 'created') {
+    sorted.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+  } else {
+    sorted.sort((a, b) => {
+      if (!a.deadline && !b.deadline) {
+        return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+      }
+      if (!a.deadline) return 1;
+      if (!b.deadline) return -1;
+      return new Date(a.deadline).getTime() - new Date(b.deadline).getTime();
+    });
+  }
+  return sorted;
+}
+
+function renderTasks() {
+  const tasks = sortTasks(getTasks());
+  taskList.innerHTML = '';
+
+  const previousCount = Number.parseInt(activeCount.textContent, 10);
+  activeCount.textContent = tasks.length;
+  if (!Number.isNaN(previousCount) && previousCount !== tasks.length) {
+    activeCount.classList.remove('queue-count__value--pulse');
+    void activeCount.offsetWidth;
+    activeCount.classList.add('queue-count__value--pulse');
+  }
+
+  if (tasks.length === 0) {
+    emptyState.style.display = 'grid';
+    taskList.appendChild(emptyState);
+    return;
+  }
+
+  emptyState.style.display = 'none';
+  if (emptyState.isConnected) {
+    emptyState.remove();
+  }
+
+  tasks.forEach((task, index) => {
+    const fragment = taskTemplate.content.cloneNode(true);
+    const card = fragment.querySelector('.task-card');
+    const title = fragment.querySelector('.task-card__title');
+    const description = fragment.querySelector('.task-card__description');
+    const deadline = fragment.querySelector('.task-card__deadline');
+    const button = fragment.querySelector('.pop-button');
+
+    card.dataset.taskId = task.id;
+    card.style.setProperty('--delay', `${index * 40}ms`);
+    title.textContent = task.title;
+    description.textContent = task.description || 'No additional details';
+    description.dataset.empty = !task.description;
+    deadline.textContent = formatDeadline(task);
+
+    button.addEventListener('click', () => popTask(card, task.id));
+    card.addEventListener('animationend', (event) => {
+      if (event.animationName === 'pop' && card.classList.contains('popping')) {
+        finalizePop(task.id);
+      }
+    });
+
+    taskList.appendChild(fragment);
+  });
+}
+
+function popTask(card, taskId) {
+  card.classList.add('popping');
+  card.style.pointerEvents = 'none';
+  const button = card.querySelector('.pop-button');
+  if (button) {
+    button.disabled = true;
+  }
+  if ('vibrate' in navigator) {
+    navigator.vibrate(30);
+  }
+}
+
+function finalizePop(taskId) {
+  const tasks = getTasks();
+  const taskIndex = tasks.findIndex((task) => task.id === taskId);
+  if (taskIndex === -1) {
+    renderTasks();
+    return;
+  }
+  const [task] = tasks.splice(taskIndex, 1);
+  saveTasks(tasks);
+  addToArchive({ ...task, completedAt: new Date().toISOString() });
+  renderTasks();
+}
+
+sortButtons.forEach((button) => {
+  button.addEventListener('click', () => {
+    setSortPreference(button.dataset.sort);
+    renderTasks();
+    if (isPanelOpen) {
+      closePanel();
+    }
+  });
+});
+
+menuToggle.addEventListener('click', () => {
+  if (isPanelOpen) {
+    closePanel();
+  } else {
+    openPanel();
+  }
+});
+
+closePanelButton.addEventListener('click', closePanel);
+panelOverlay.addEventListener('click', closePanel);
+
+setSortPreference(sortPreference);
+renderTasks();
+
+window.addEventListener('focus', renderTasks);

--- a/scripts/storage.js
+++ b/scripts/storage.js
@@ -1,0 +1,66 @@
+const TASK_KEY = 'poptask_tasks';
+const ARCHIVE_KEY = 'poptask_archive';
+
+export function getTasks() {
+  try {
+    const raw = localStorage.getItem(TASK_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch (error) {
+    console.error('Unable to read tasks from storage', error);
+    return [];
+  }
+}
+
+export function saveTasks(tasks) {
+  try {
+    localStorage.setItem(TASK_KEY, JSON.stringify(tasks));
+  } catch (error) {
+    console.error('Unable to save tasks to storage', error);
+  }
+}
+
+export function getArchive() {
+  try {
+    const raw = localStorage.getItem(ARCHIVE_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch (error) {
+    console.error('Unable to read archive from storage', error);
+    return [];
+  }
+}
+
+export function saveArchive(tasks) {
+  try {
+    localStorage.setItem(ARCHIVE_KEY, JSON.stringify(tasks));
+  } catch (error) {
+    console.error('Unable to save archive to storage', error);
+  }
+}
+
+export function generateId() {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  return `task-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+}
+
+export function addTask(task) {
+  const tasks = getTasks();
+  tasks.push(task);
+  saveTasks(tasks);
+}
+
+export function removeTask(id) {
+  const tasks = getTasks().filter((task) => task.id !== id);
+  saveTasks(tasks);
+}
+
+export function addToArchive(task) {
+  const archive = getArchive();
+  archive.unshift(task);
+  saveArchive(archive);
+}
+
+export function clearArchive() {
+  saveArchive([]);
+}

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,0 +1,740 @@
+:root {
+  color-scheme: light;
+  --background: linear-gradient(165deg, #f3f4ff 0%, #fdf2ff 40%, #ffffff 100%);
+  --surface: rgba(255, 255, 255, 0.58);
+  --surface-strong: rgba(255, 255, 255, 0.74);
+  --surface-border: rgba(255, 255, 255, 0.4);
+  --primary: #605bff;
+  --primary-dark: #4b42e5;
+  --accent: #ff9ae2;
+  --text: rgba(29, 30, 45, 0.9);
+  --muted-text: rgba(29, 30, 45, 0.64);
+  --shadow: 0 18px 48px rgba(31, 34, 68, 0.14);
+  --radius-xl: 28px;
+  --radius-lg: 22px;
+  --radius-md: 16px;
+  --radius-sm: 12px;
+  --transition-fast: 180ms ease;
+  --transition-base: 320ms cubic-bezier(0.22, 0.61, 0.36, 1);
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background-color: #f6f7ff;
+  background-image: var(--background);
+  min-height: 100%;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: inherit;
+  color: var(--text);
+  background: var(--background);
+  display: flex;
+  justify-content: center;
+  position: relative;
+  padding-bottom: 120px;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(96, 91, 255, 0.08), transparent 55%),
+    radial-gradient(circle at 80% 10%, rgba(255, 154, 226, 0.08), transparent 60%),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0.1));
+  pointer-events: none;
+  z-index: -2;
+}
+
+body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  backdrop-filter: blur(36px) saturate(120%);
+  pointer-events: none;
+  z-index: -3;
+}
+
+h1,
+h2,
+h3,
+h4 {
+  margin: 0;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+p {
+  margin: 0;
+  line-height: 1.5;
+  color: var(--muted-text);
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.app-shell {
+  width: min(560px, 100vw);
+  padding: clamp(24px, 7vw, 48px) clamp(18px, 6vw, 48px);
+}
+
+.app-header {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 16px;
+  padding: 18px 20px;
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+  border: 1px solid var(--surface-border);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(22px);
+}
+
+.app-heading h1 {
+  font-size: clamp(1.75rem, 5vw, 2.25rem);
+  text-align: center;
+  color: var(--text);
+}
+
+.icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: rgba(255, 255, 255, 0.45);
+  color: var(--primary);
+  font-size: 1.4rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--transition-fast), transform var(--transition-fast), border-color var(--transition-fast);
+}
+
+.icon-button:hover,
+.icon-button:focus-visible {
+  background: rgba(255, 255, 255, 0.7);
+  border-color: rgba(96, 91, 255, 0.26);
+  transform: translateY(-2px);
+}
+
+.queue-count {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 14px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.4);
+  color: var(--primary);
+  font-weight: 600;
+  font-size: 0.95rem;
+  border: 1px solid rgba(96, 91, 255, 0.18);
+}
+
+.queue-count__value {
+  font-size: 1.1rem;
+  color: var(--text);
+  transition: transform var(--transition-fast), color var(--transition-fast);
+}
+
+.queue-count__value.queue-count__value--pulse {
+  animation: countPulse 420ms ease;
+}
+
+.queue-count__label {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.7rem;
+  color: var(--muted-text);
+}
+
+.app-main {
+  margin-top: clamp(28px, 7vw, 52px);
+  display: grid;
+  gap: clamp(18px, 6vw, 32px);
+}
+
+.task-list {
+  display: grid;
+  gap: clamp(14px, 4vw, 24px);
+}
+
+.task-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 16px;
+  padding: clamp(20px, 6vw, 28px);
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+  border: 1px solid var(--surface-border);
+  box-shadow: var(--shadow);
+  position: relative;
+  overflow: hidden;
+  backdrop-filter: blur(26px);
+  transition: transform var(--transition-base), box-shadow var(--transition-base), border-color var(--transition-fast);
+  animation: floatIn 420ms var(--transition-base) both;
+  animation-delay: var(--delay, 0ms);
+}
+
+.task-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(96, 91, 255, 0.14), rgba(255, 154, 226, 0.1));
+  opacity: 0;
+  transition: opacity var(--transition-fast);
+}
+
+.task-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 24px 56px rgba(37, 37, 70, 0.18);
+  border-color: rgba(96, 91, 255, 0.35);
+}
+
+.task-card:hover::after {
+  opacity: 1;
+}
+
+.task-card__title {
+  font-size: 1.125rem;
+  color: var(--text);
+}
+
+.task-card__deadline {
+  margin-top: 6px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--primary);
+}
+
+.task-card__description {
+  margin-top: 14px;
+  font-size: 0.95rem;
+  color: var(--muted-text);
+  max-width: 60ch;
+}
+
+.task-card__description[data-empty="true"] {
+  font-style: italic;
+  color: rgba(29, 30, 45, 0.5);
+}
+
+.task-card__actions {
+  display: flex;
+  align-items: flex-end;
+}
+
+.pop-button {
+  border: none;
+  border-radius: 999px;
+  padding: 12px 22px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  background: linear-gradient(135deg, rgba(96, 91, 255, 0.9), rgba(255, 154, 226, 0.9));
+  color: white;
+  cursor: pointer;
+  box-shadow: 0 20px 40px rgba(59, 53, 173, 0.25);
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.pop-button:focus-visible,
+.pop-button:hover {
+  transform: translateY(-2px) scale(1.04);
+  box-shadow: 0 28px 52px rgba(59, 53, 173, 0.28);
+}
+
+.task-card.popping {
+  animation: pop 420ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+@keyframes pop {
+  0% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  35% {
+    transform: scale(1.05);
+  }
+  60% {
+    transform: scale(0.94) translateY(6px);
+  }
+  100% {
+    transform: scale(1.12) translateY(-8px);
+    opacity: 0;
+  }
+}
+
+@keyframes floatIn {
+  0% {
+    opacity: 0;
+    transform: translateY(18px) scale(0.98);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes countPulse {
+  0% {
+    transform: scale(1);
+  }
+  40% {
+    transform: scale(1.15);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+.empty-state {
+  text-align: center;
+  padding: clamp(36px, 10vw, 60px);
+  border-radius: var(--radius-lg);
+  background: rgba(255, 255, 255, 0.42);
+  border: 1px dashed rgba(96, 91, 255, 0.2);
+  backdrop-filter: blur(24px);
+  display: grid;
+  gap: 12px;
+  justify-items: center;
+  color: var(--muted-text);
+}
+
+.empty-state h2 {
+  font-size: 1.3rem;
+  color: var(--text);
+}
+
+.fab {
+  position: fixed;
+  bottom: clamp(26px, 7vw, 48px);
+  left: 50%;
+  transform: translateX(-50%);
+  width: 68px;
+  height: 68px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, rgba(96, 91, 255, 0.95), rgba(255, 154, 226, 0.95));
+  color: white;
+  display: grid;
+  place-items: center;
+  font-size: 2rem;
+  font-weight: 700;
+  box-shadow: 0 28px 52px rgba(53, 48, 150, 0.28);
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.fab:focus-visible,
+.fab:hover {
+  transform: translate(-50%, -4px) scale(1.05);
+  box-shadow: 0 36px 60px rgba(53, 48, 150, 0.32);
+}
+
+.panel-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(17, 19, 35, 0.24);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--transition-base);
+  z-index: 8;
+}
+
+.panel-overlay.is-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.action-panel {
+  position: fixed;
+  left: 50%;
+  bottom: 0;
+  transform: translate(-50%, 110%);
+  width: min(520px, calc(100vw - 32px));
+  background: rgba(255, 255, 255, 0.82);
+  border: 1px solid var(--surface-border);
+  border-radius: 28px 28px 16px 16px;
+  box-shadow: 0 -18px 48px rgba(28, 26, 77, 0.22);
+  backdrop-filter: blur(28px);
+  padding: clamp(24px, 6vw, 36px);
+  display: grid;
+  gap: 24px;
+  z-index: 9;
+  transition: transform var(--transition-base);
+}
+
+.action-panel.is-visible {
+  transform: translate(-50%, 0);
+}
+
+.action-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.action-panel__header h2 {
+  font-size: 1.2rem;
+}
+
+.action-panel__section {
+  display: grid;
+  gap: 12px;
+}
+
+.action-panel__section h3 {
+  font-size: 1rem;
+  color: var(--text);
+}
+
+.action-panel__section p {
+  color: var(--muted-text);
+  font-size: 0.95rem;
+}
+
+.panel-toggle {
+  display: inline-flex;
+  gap: 10px;
+  padding: 6px;
+  background: rgba(255, 255, 255, 0.4);
+  border-radius: 999px;
+  border: 1px solid rgba(96, 91, 255, 0.18);
+}
+
+.panel-toggle__chip {
+  border: none;
+  background: transparent;
+  padding: 10px 18px;
+  border-radius: 999px;
+  font-weight: 600;
+  color: var(--muted-text);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast), transform var(--transition-fast);
+}
+
+.panel-toggle__chip[aria-checked='true'] {
+  background: linear-gradient(135deg, rgba(96, 91, 255, 0.95), rgba(255, 154, 226, 0.95));
+  color: white;
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(53, 48, 150, 0.26);
+}
+
+.panel-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 18px;
+  border-radius: 999px;
+  background: rgba(96, 91, 255, 0.12);
+  color: var(--primary);
+  font-weight: 600;
+  border: 1px solid rgba(96, 91, 255, 0.22);
+  transition: background var(--transition-fast), transform var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.panel-link:hover,
+.panel-link:focus-visible {
+  background: rgba(96, 91, 255, 0.2);
+  transform: translateY(-2px);
+  box-shadow: 0 16px 32px rgba(53, 48, 150, 0.2);
+}
+
+@supports not (backdrop-filter: blur(1px)) {
+  body::after {
+    background: rgba(255, 255, 255, 0.92);
+  }
+
+  .app-header,
+  .task-card,
+  .empty-state,
+  .action-panel {
+    background: rgba(255, 255, 255, 0.95);
+  }
+}
+
+@media (max-width: 520px) {
+  .app-header {
+    grid-template-columns: auto auto;
+    justify-content: space-between;
+  }
+
+  .app-heading {
+    justify-self: center;
+  }
+
+  .task-card {
+    grid-template-columns: 1fr;
+  }
+
+  .task-card__actions {
+    justify-content: flex-start;
+  }
+}
+
+.form-page,
+.archive-page {
+  width: 100%;
+  max-width: 640px;
+  margin: 0 auto;
+  padding: clamp(16px, 4vw, 32px);
+}
+
+.form-header,
+.archive-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: clamp(24px, 5vw, 36px);
+}
+
+.form-header h1,
+.archive-header h1 {
+  font-size: clamp(1.8rem, 5vw, 2.4rem);
+}
+
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(99, 91, 255, 0.15);
+  font-size: 1.5rem;
+  color: var(--primary);
+  transition: transform var(--transition-fast);
+}
+
+.back-link:hover,
+.back-link:focus-visible {
+  transform: translateY(-2px);
+}
+
+.back-link.placeholder {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.task-form {
+  display: grid;
+  gap: clamp(20px, 4vw, 28px);
+  background: var(--surface-strong);
+  padding: clamp(24px, 5vw, 36px);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow);
+  border: 1px solid rgba(255, 255, 255, 0.75);
+}
+
+.field-group {
+  display: grid;
+  gap: 12px;
+}
+
+.field-group label,
+legend {
+  font-weight: 600;
+  color: var(--text);
+}
+
+input[type="text"],
+textarea,
+input[type="date"],
+input[type="time"],
+select {
+  width: 100%;
+  padding: 14px 16px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(99, 91, 255, 0.18);
+  background: rgba(255, 255, 255, 0.9);
+  font-size: 1rem;
+  color: var(--text);
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+  font-family: inherit;
+}
+
+.is-invalid {
+  border-color: #ff6b6b !important;
+  box-shadow: 0 0 0 3px rgba(255, 107, 107, 0.2) !important;
+}
+
+input:focus,
+textarea:focus,
+select:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(99, 91, 255, 0.18);
+}
+
+.radio-grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.radio-chip {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 16px;
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(99, 91, 255, 0.15);
+  cursor: pointer;
+  transition: background var(--transition-fast), border-color var(--transition-fast), transform var(--transition-fast);
+}
+
+.radio-chip input {
+  position: absolute;
+  opacity: 0;
+  inset: 0;
+  cursor: pointer;
+}
+
+.radio-chip:has(input:checked) {
+  background: linear-gradient(135deg, rgba(99, 91, 255, 0.12), rgba(255, 144, 232, 0.12));
+  border-color: rgba(99, 91, 255, 0.45);
+  transform: translateY(-2px);
+}
+
+.deadline-field {
+  display: grid;
+  gap: 12px;
+  margin-top: 16px;
+  padding: 16px;
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.6);
+  border: 1px dashed rgba(99, 91, 255, 0.18);
+}
+
+.form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.primary-button,
+.secondary-button,
+.clear-archive {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 14px 22px;
+  border-radius: 999px;
+  font-weight: 700;
+  text-decoration: none;
+  border: none;
+  cursor: pointer;
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.primary-button {
+  background: linear-gradient(135deg, var(--primary), var(--accent));
+  color: white;
+  box-shadow: 0 16px 32px rgba(99, 91, 255, 0.18);
+}
+
+.primary-button:hover,
+.primary-button:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 44px rgba(99, 91, 255, 0.22);
+}
+
+.secondary-button,
+.clear-archive {
+  background: rgba(255, 255, 255, 0.75);
+  color: var(--text);
+  border: 1px solid rgba(99, 91, 255, 0.18);
+}
+
+.secondary-button:hover,
+.secondary-button:focus-visible,
+.clear-archive:hover,
+.clear-archive:focus-visible {
+  transform: translateY(-2px);
+}
+
+.archive-main {
+  display: grid;
+  gap: 16px;
+}
+
+.archive-card {
+  padding: clamp(18px, 4vw, 24px);
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+  border: 1px solid rgba(255, 255, 255, 0.7);
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 8px;
+}
+
+.archive-card__meta {
+  font-size: 0.9rem;
+  color: var(--muted-text);
+}
+
+@media (max-width: 720px) {
+  .app-shell {
+    padding-bottom: 140px;
+  }
+
+  .task-card {
+    grid-template-columns: 1fr;
+  }
+
+  .task-card__actions {
+    justify-content: flex-end;
+  }
+
+  .fab {
+    width: 56px;
+    height: 56px;
+    font-size: 1.8rem;
+  }
+}
+
+@media (max-width: 480px) {
+  body {
+    background: #f6f5ff;
+  }
+
+  .app-shell {
+    padding: 24px 16px 120px;
+  }
+
+  .summary-card {
+    border-radius: 24px;
+  }
+
+  .task-card {
+    border-radius: 20px;
+  }
+
+  .primary-button,
+  .secondary-button,
+  .clear-archive {
+    flex: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary
- simplify the home header with a compact count pill and centered add control
- move sorting and archive access into a slide-up quick menu on glass panels
- refresh task cards with frosted styling, smooth motion, and count pulse feedback

## Testing
- python -m http.server 4173

------
https://chatgpt.com/codex/tasks/task_e_68e5d98f672c83268fd6e87d11b12a0f